### PR TITLE
Add initial Flask-based LIMS prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+lims.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # LIMS
+
+A minimal Laboratory Information Management System using Flask and MySQL (via SQLAlchemy). This prototype replaces an MS Access database with a web interface and includes basic audit logging and role-based permissions.
+
+## Features
+
+- Manage samples and associated tests
+- Change logging with user and timestamp stored in `AuditLog`
+- Role-based permissions: only admin can un-release samples; analyst and checker must differ
+- Tests become read-only once a sample is released
+
+## Setup
+
+```bash
+pip install -r requirements.txt  # optional; or install Flask, Flask-Login, Flask-SQLAlchemy, PyMySQL
+flask --app lims.app create-app init-db  # creates SQLite database and admin user
+flask --app lims.app run
+```
+
+The app uses SQLite by default. Set the `DATABASE_URI` environment variable to connect to MySQL, for example:
+
+```bash
+export DATABASE_URI="mysql+pymysql://user:password@localhost/lims"
+```
+
+Then run `flask --app lims.app run`.
+
+Login with username `admin` and password `admin`.

--- a/lims/app.py
+++ b/lims/app.py
@@ -1,0 +1,46 @@
+from flask import Flask
+from flask_login import LoginManager
+from werkzeug.security import generate_password_hash
+
+from .models import db, User
+from .auth import bp as auth_bp
+from .main import bp as main_bp
+
+
+def create_app(test_config=None):
+    app = Flask(__name__)
+    app.config['SECRET_KEY'] = 'dev'
+    app.config['SQLALCHEMY_DATABASE_URI'] = (
+        app.config.get('DATABASE_URI')
+        or 'sqlite:///lims.db'
+    )
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    if test_config:
+        app.config.update(test_config)
+
+    db.init_app(app)
+    login_manager = LoginManager()
+    login_manager.login_view = 'auth.login'
+    login_manager.init_app(app)
+
+    @login_manager.user_loader
+    def load_user(user_id):
+        return User.query.get(int(user_id))
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(main_bp)
+
+    @app.cli.command('init-db')
+    def init_db():
+        db.create_all()
+        if not User.query.filter_by(username='admin').first():
+            admin = User(
+                username='admin',
+                password=generate_password_hash('admin'),
+                role='admin'
+            )
+            db.session.add(admin)
+            db.session.commit()
+        print('Database initialized')
+
+    return app

--- a/lims/auth.py
+++ b/lims/auth.py
@@ -1,0 +1,27 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+from flask_login import login_user, logout_user, login_required
+from werkzeug.security import check_password_hash
+
+from .models import User
+
+bp = Blueprint('auth', __name__)
+
+
+@bp.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and check_password_hash(user.password, password):
+            login_user(user)
+            return redirect(url_for('main.sample_list'))
+        flash('Invalid credentials')
+    return render_template('login.html')
+
+
+@bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('auth.login'))

--- a/lims/main.py
+++ b/lims/main.py
@@ -1,0 +1,124 @@
+from datetime import date
+from flask import Blueprint, render_template, request, redirect, url_for, flash
+from flask_login import login_required, current_user
+
+from .models import db, Sample, Test, User, AuditLog
+
+bp = Blueprint('main', __name__)
+
+
+def log_change(table, record_id, field, old, new):
+    if old == new:
+        return
+    entry = AuditLog(
+        table_name=table,
+        record_id=record_id,
+        field_name=field,
+        old_value=str(old) if old is not None else '',
+        new_value=str(new) if new is not None else '',
+        changed_by=current_user.id if current_user.is_authenticated else None,
+    )
+    db.session.add(entry)
+
+
+@bp.route('/')
+@login_required
+def index():
+    return redirect(url_for('main.sample_list'))
+
+
+@bp.route('/samples')
+@login_required
+def sample_list():
+    samples = Sample.query.all()
+    return render_template('samples.html', samples=samples)
+
+
+@bp.route('/sample/<int:sample_id>', methods=['GET', 'POST'])
+@login_required
+def sample_detail(sample_id):
+    sample = Sample.query.get_or_404(sample_id)
+    if request.method == 'POST':
+        if sample.released and not current_user.role == 'admin':
+            flash('Released samples cannot be edited.')
+            return redirect(url_for('main.sample_detail', sample_id=sample_id))
+        old_job = sample.job_number
+        old_desc = sample.description
+        old_date = sample.received_date
+        old_released = sample.released
+        sample.job_number = request.form['job_number']
+        sample.description = request.form['description']
+        sample.received_date = request.form['received_date'] or None
+        sample.released = 'released' in request.form
+        if old_released and not sample.released and current_user.role != 'admin':
+            flash('Only admin can un-release a sample.')
+            sample.released = True
+        log_change('sample', sample.id, 'job_number', old_job, sample.job_number)
+        log_change('sample', sample.id, 'description', old_desc, sample.description)
+        log_change('sample', sample.id, 'received_date', old_date, sample.received_date)
+        log_change('sample', sample.id, 'released', old_released, sample.released)
+        db.session.commit()
+        flash('Sample updated')
+    return render_template('sample_detail.html', sample=sample)
+
+
+@bp.route('/sample/new', methods=['GET', 'POST'])
+@login_required
+def sample_new():
+    if request.method == 'POST':
+        sample = Sample(
+            job_number=request.form['job_number'],
+            description=request.form['description'],
+            received_date=request.form['received_date'] or None,
+        )
+        db.session.add(sample)
+        db.session.commit()
+        flash('Sample created')
+        return redirect(url_for('main.sample_detail', sample_id=sample.id))
+    return render_template('sample_detail.html', sample=None)
+
+
+@bp.route('/sample/<int:sample_id>/add_test', methods=['POST'])
+@login_required
+def add_test(sample_id):
+    sample = Sample.query.get_or_404(sample_id)
+    if sample.released:
+        flash('Cannot add tests to released sample')
+        return redirect(url_for('main.sample_detail', sample_id=sample_id))
+    test = Test(
+        sample=sample,
+        test_name=request.form['test_name'],
+        method=request.form['method'],
+        specification=request.form['specification'],
+        result=request.form['result'],
+        analyst_id=request.form['analyst_id'] or None,
+        checker_id=request.form['checker_id'] or None,
+    )
+    if test.analyst_id and test.analyst_id == test.checker_id:
+        flash('Analyst and checker must be different users.')
+        return redirect(url_for('main.sample_detail', sample_id=sample_id))
+    db.session.add(test)
+    db.session.commit()
+    flash('Test added')
+    return redirect(url_for('main.sample_detail', sample_id=sample_id))
+
+
+@bp.route('/test/<int:test_id>/update', methods=['POST'])
+@login_required
+def update_test(test_id):
+    test = Test.query.get_or_404(test_id)
+    sample = test.sample
+    if sample.released:
+        flash('Released samples cannot be edited')
+        return redirect(url_for('main.sample_detail', sample_id=sample.id))
+    old_result = test.result
+    test.result = request.form['result']
+    test.analyst_id = request.form['analyst_id'] or None
+    test.checker_id = request.form['checker_id'] or None
+    if test.analyst_id and test.analyst_id == test.checker_id:
+        flash('Analyst and checker must differ')
+        return redirect(url_for('main.sample_detail', sample_id=sample.id))
+    db.session.commit()
+    log_change('test', test.id, 'result', old_result, test.result)
+    flash('Test updated')
+    return redirect(url_for('main.sample_detail', sample_id=sample.id))

--- a/lims/models.py
+++ b/lims/models.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import UserMixin
+
+
+db = SQLAlchemy()
+
+
+class AuditLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    table_name = db.Column(db.String(50))
+    record_id = db.Column(db.Integer)
+    field_name = db.Column(db.String(50))
+    old_value = db.Column(db.String(255))
+    new_value = db.Column(db.String(255))
+    changed_by = db.Column(db.Integer, db.ForeignKey('user.id'))
+    changed_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password = db.Column(db.String(255), nullable=False)
+    role = db.Column(db.String(20), nullable=False, default='analyst')
+
+    def __repr__(self):
+        return f'<User {self.username}>'
+
+
+class Sample(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    job_number = db.Column(db.String(50), unique=True, nullable=False)
+    description = db.Column(db.String(255))
+    received_date = db.Column(db.Date)
+    released = db.Column(db.Boolean, default=False)
+
+    tests = db.relationship('Test', backref='sample', cascade='all, delete-orphan')
+
+    def __repr__(self):
+        return f'<Sample {self.job_number}>'
+
+
+class Test(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    sample_id = db.Column(db.Integer, db.ForeignKey('sample.id'), nullable=False)
+    test_name = db.Column(db.String(120))
+    method = db.Column(db.String(120))
+    specification = db.Column(db.String(120))
+    result = db.Column(db.String(120))
+    analyst_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    checker_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    released = db.Column(db.Boolean, default=False)
+
+    analyst = db.relationship('User', foreign_keys=[analyst_id], backref='analysed_tests')
+    checker = db.relationship('User', foreign_keys=[checker_id], backref='checked_tests')
+
+    def __repr__(self):
+        return f'<Test {self.test_name}>'

--- a/lims/static/style.css
+++ b/lims/static/style.css
@@ -1,0 +1,24 @@
+body {
+  font-family: sans-serif;
+}
+.layout {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  min-height: 100vh;
+}
+.menu {
+  background: #eee;
+  padding: 1rem;
+}
+.content {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+.sample-info {
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 1rem;
+}
+.tests {
+  margin-top: 1rem;
+}

--- a/lims/templates/base.html
+++ b/lims/templates/base.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>LIMS</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  </head>
+  <body>
+    <div class="layout">
+      <nav class="menu">
+        <ul>
+          <li><a href="{{ url_for('main.sample_list') }}">Samples</a></li>
+          <li><a href="{{ url_for('auth.logout') }}">Logout</a></li>
+        </ul>
+      </nav>
+      <main class="content">
+        {% block content %}{% endblock %}
+      </main>
+    </div>
+  </body>
+</html>

--- a/lims/templates/login.html
+++ b/lims/templates/login.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Login</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  </head>
+  <body>
+    <h2>Login</h2>
+    <form method="post">
+      <label>Username <input name="username"></label>
+      <label>Password <input type="password" name="password"></label>
+      <button type="submit">Login</button>
+    </form>
+  </body>
+</html>

--- a/lims/templates/sample_detail.html
+++ b/lims/templates/sample_detail.html
@@ -1,0 +1,60 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ 'New Sample' if not sample else 'Sample ' ~ sample.job_number }}</h2>
+<div class="sample-info">
+  <form method="post">
+    <label>Job Number
+      <input name="job_number" value="{{ sample.job_number if sample else '' }}" required>
+    </label>
+    <label>Description
+      <input name="description" value="{{ sample.description if sample else '' }}">
+    </label>
+    <label>Received Date
+      <input type="date" name="received_date" value="{{ sample.received_date }}">
+    </label>
+    <label>Released
+      <input type="checkbox" name="released" {% if sample and sample.released %}checked{% endif %}>
+    </label>
+    <button type="submit">Save</button>
+  </form>
+</div>
+{% if sample %}
+<div class="tests">
+  <h3>Tests</h3>
+  <table>
+    <tr><th>Name</th><th>Method</th><th>Spec</th><th>Result</th><th>Analyst</th><th>Checker</th><th></th></tr>
+    {% for t in sample.tests %}
+    <tr>
+      <form action="{{ url_for('main.update_test', test_id=t.id) }}" method="post">
+        <td>{{ t.test_name }}</td>
+        <td>{{ t.method }}</td>
+        <td>{{ t.specification }}</td>
+        <td><input name="result" value="{{ t.result }}" {% if sample.released %}readonly{% endif %}></td>
+        <td>
+          <input name="analyst_id" value="{{ t.analyst_id or '' }}" {% if sample.released %}readonly{% endif %}>
+        </td>
+        <td>
+          <input name="checker_id" value="{{ t.checker_id or '' }}" {% if sample.released %}readonly{% endif %}>
+        </td>
+        <td>
+          {% if not sample.released %}<button type="submit">Update</button>{% endif %}
+        </td>
+      </form>
+    </tr>
+    {% endfor %}
+  </table>
+  {% if not sample.released %}
+  <h4>Add Test</h4>
+  <form action="{{ url_for('main.add_test', sample_id=sample.id) }}" method="post">
+    <input name="test_name" placeholder="Test name" required>
+    <input name="method" placeholder="Method">
+    <input name="specification" placeholder="Specification">
+    <input name="result" placeholder="Result">
+    <input name="analyst_id" placeholder="Analyst ID">
+    <input name="checker_id" placeholder="Checker ID">
+    <button type="submit">Add</button>
+  </form>
+  {% endif %}
+</div>
+{% endif %}
+{% endblock %}

--- a/lims/templates/samples.html
+++ b/lims/templates/samples.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Samples</h2>
+<a href="{{ url_for('main.sample_new') }}">New Sample</a>
+<table>
+  <tr><th>Job Number</th><th>Description</th><th>Released</th></tr>
+  {% for s in samples %}
+  <tr>
+    <td><a href="{{ url_for('main.sample_detail', sample_id=s.id) }}">{{ s.job_number }}</a></td>
+    <td>{{ s.description }}</td>
+    <td>{{ 'Yes' if s.released else 'No' }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+flask_sqlalchemy
+flask_login
+pymysql

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lims.app import create_app
+
+
+def test_config():
+    app = create_app({'TESTING': True})
+    assert app.config['TESTING']


### PR DESCRIPTION
## Summary
- implement Flask web app with SQLAlchemy models for samples, tests, users, and audit logs
- add views with role-based permissions and read-only tests after release
- document setup instructions and add basic pytest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6352197d0832d901011784fd98b3e