### PR TITLE
docs: update flask CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A minimal Laboratory Information Management System using Flask and MySQL (via SQ
 
 ```bash
 pip install -r requirements.txt  # optional; or install Flask, Flask-Login, Flask-SQLAlchemy, PyMySQL
-flask --app lims.app create-app init-db  # creates SQLite database and admin user
-flask --app lims.app run
+flask --app lims.app:create_app init-db  # creates SQLite database and admin user
+flask --app lims.app:create_app run --host 0.0.0.0
 ```
 
 The app uses SQLite by default. Set the `DATABASE_URI` environment variable to connect to MySQL, for example:
@@ -23,6 +23,6 @@ The app uses SQLite by default. Set the `DATABASE_URI` environment variable to c
 export DATABASE_URI="mysql+pymysql://user:password@localhost/lims"
 ```
 
-Then run `flask --app lims.app run`.
+Then run `flask --app lims.app:create_app run --host 0.0.0.0`.
 
 Login with username `admin` and password `admin`.


### PR DESCRIPTION
## Summary
- document correct Flask app factory usage
- note running the server on 0.0.0.0 for external access

## Testing
- `flask --app lims.app:create_app init-db`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b638e21658832da34775395be66b9d