### PR TITLE
fix: run flask via python in systemd service

### DIFF
--- a/lims.service
+++ b/lims.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 WorkingDirectory=/opt/lims
 Environment="PATH=/opt/lims/.venv/bin"
-ExecStart=/opt/lims/.venv/bin/flask --app lims.app:create_app run --host 0.0.0.0 --port 8000
+ExecStart=/opt/lims/.venv/bin/python -m flask --app lims.app:create_app run --host 0.0.0.0 --port 8000
 Restart=always
 User=www-data
 Group=www-data


### PR DESCRIPTION
## Summary
- avoid missing binary error by invoking Flask via the Python interpreter in `lims.service`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b63c225200832d8d7898a7953d7c69