### PR TITLE
style: add dark theme layout

### DIFF
--- a/lims/static/style.css
+++ b/lims/static/style.css
@@ -1,24 +1,116 @@
-body {
-  font-family: sans-serif;
+:root {
+  --bg-color: #1e1e2d;
+  --text-color: #f5f5f5;
+  --sidebar-bg: #27293d;
+  --header-bg: #1f1d2b;
+  --card-bg: #2a2d3e;
+  --accent: #4e8ef7;
+  --input-bg: #1f1d2b;
+  --input-border: #444;
+  --link-color: #4e8ef7;
 }
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
 .layout {
   display: grid;
-  grid-template-columns: 200px 1fr;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 60px 1fr;
   min-height: 100vh;
 }
-.menu {
-  background: #eee;
+
+.sidebar {
+  grid-row: 1 / span 2;
+  background: var(--sidebar-bg);
   padding: 1rem;
 }
+
+.sidebar .brand {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar a {
+  color: var(--text-color);
+  text-decoration: none;
+  display: block;
+  padding: 0.5rem 0;
+}
+
+.main {
+  display: grid;
+  grid-template-rows: 60px 1fr;
+}
+
+.topbar {
+  background: var(--header-bg);
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
 .content {
   padding: 1rem;
-  display: flex;
-  flex-direction: column;
 }
-.sample-info {
-  border-bottom: 1px solid #ccc;
-  padding-bottom: 1rem;
+
+.card {
+  background: var(--card-bg);
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
-.tests {
-  margin-top: 1rem;
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 0.5rem;
+  text-align: left;
+}
+
+table tr {
+  border-bottom: 1px solid rgba(255,255,255,0.1);
+}
+
+a {
+  color: var(--link-color);
+}
+
+button, input, select {
+  background: var(--input-bg);
+  color: var(--text-color);
+  border: 1px solid var(--input-border);
+  padding: 0.4rem;
+  border-radius: 4px;
+}
+
+button {
+  background: var(--accent);
+  border: none;
+  cursor: pointer;
+}
+
+.login-container {
+  max-width: 300px;
+  margin: 10% auto;
+  background: var(--card-bg);
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }

--- a/lims/templates/base.html
+++ b/lims/templates/base.html
@@ -7,18 +7,28 @@
   </head>
   <body>
     <div class="layout">
-      <nav class="menu">
-        <ul>
-          <li><a href="{{ url_for('main.sample_list') }}">Samples</a></li>
-          {% if current_user.is_authenticated and current_user.role == 'admin' %}
-          <li><a href="{{ url_for('main.update_app') }}">Update</a></li>
+      <aside class="sidebar">
+        <div class="brand">LIMS</div>
+        <nav>
+          <ul>
+            <li><a href="{{ url_for('main.sample_list') }}">Samples</a></li>
+            {% if current_user.is_authenticated and current_user.role == 'admin' %}
+            <li><a href="{{ url_for('main.update_app') }}">Update</a></li>
+            {% endif %}
+            <li><a href="{{ url_for('auth.logout') }}">Logout</a></li>
+          </ul>
+        </nav>
+      </aside>
+      <div class="main">
+        <header class="topbar">
+          {% if current_user.is_authenticated %}
+          <span>{{ current_user.username }}</span>
           {% endif %}
-          <li><a href="{{ url_for('auth.logout') }}">Logout</a></li>
-        </ul>
-      </nav>
-      <main class="content">
-        {% block content %}{% endblock %}
-      </main>
+        </header>
+        <main class="content">
+          {% block content %}{% endblock %}
+        </main>
+      </div>
     </div>
   </body>
 </html>

--- a/lims/templates/login.html
+++ b/lims/templates/login.html
@@ -6,11 +6,13 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
   <body>
-    <h2>Login</h2>
-    <form method="post">
-      <label>Username <input name="username"></label>
-      <label>Password <input type="password" name="password"></label>
-      <button type="submit">Login</button>
-    </form>
+    <div class="login-container">
+      <h2>Login</h2>
+      <form method="post">
+        <label>Username <input name="username"></label>
+        <label>Password <input type="password" name="password"></label>
+        <button type="submit">Login</button>
+      </form>
+    </div>
   </body>
 </html>

--- a/lims/templates/sample_detail.html
+++ b/lims/templates/sample_detail.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>{{ 'New Sample' if not sample else 'Sample ' ~ sample.job_number }}</h2>
-<div class="sample-info">
+<div class="card sample-info">
   <form method="post">
     <label>Job Number
       <input name="job_number" value="{{ sample.job_number if sample else '' }}" required>
@@ -19,7 +19,7 @@
   </form>
 </div>
 {% if sample %}
-<div class="tests">
+<div class="card tests">
   <h3>Tests</h3>
   <table>
     <tr><th>Name</th><th>Method</th><th>Spec</th><th>Result</th><th>Analyst</th><th>Checker</th><th></th></tr>

--- a/lims/templates/samples.html
+++ b/lims/templates/samples.html
@@ -1,15 +1,17 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Samples</h2>
-<a href="{{ url_for('main.sample_new') }}">New Sample</a>
-<table>
-  <tr><th>Job Number</th><th>Description</th><th>Released</th></tr>
-  {% for s in samples %}
-  <tr>
-    <td><a href="{{ url_for('main.sample_detail', sample_id=s.id) }}">{{ s.job_number }}</a></td>
-    <td>{{ s.description }}</td>
-    <td>{{ 'Yes' if s.released else 'No' }}</td>
-  </tr>
-  {% endfor %}
-</table>
+<div class="card">
+  <a href="{{ url_for('main.sample_new') }}">New Sample</a>
+  <table>
+    <tr><th>Job Number</th><th>Description</th><th>Released</th></tr>
+    {% for s in samples %}
+    <tr>
+      <td><a href="{{ url_for('main.sample_detail', sample_id=s.id) }}">{{ s.job_number }}</a></td>
+      <td>{{ s.description }}</td>
+      <td>{{ 'Yes' if s.released else 'No' }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add dark theme, sidebar, and header layout
- wrap sample views and login in card-based sections

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b63d3ce9a0832d8c7c1f1fb5358557